### PR TITLE
Provided the ability to get the stars parent

### DIFF
--- a/src/starwars.js
+++ b/src/starwars.js
@@ -129,7 +129,7 @@
                     $(this).siblings("input." + starwarsjs.input_class).val(star_id);
                     $(this).prevAll().andSelf().addClass(starwarsjs.checked_class);
                     $(this).nextAll().removeClass(starwarsjs.checked_class);
-                    starwarsjs.active_element = this.parentElement;
+                    starwarsjs.active_element = $(this).parent();
                     if (starwarsjs.on_select && typeof starwarsjs.on_select === "function"){
 
                         starwarsjs.on_select(star_id);

--- a/src/starwars.js
+++ b/src/starwars.js
@@ -20,6 +20,7 @@
             disable: settings.disable,
             checked_class : "checked",
             disable_class : "disable",
+            active_element : null,
             input_class : "get_rate",
             default_stars : settings.default_stars,
             on_select : settings.on_select
@@ -128,7 +129,7 @@
                     $(this).siblings("input." + starwarsjs.input_class).val(star_id);
                     $(this).prevAll().andSelf().addClass(starwarsjs.checked_class);
                     $(this).nextAll().removeClass(starwarsjs.checked_class);
-
+                    starwarsjs.active_element = this.parentElement;
                     if (starwarsjs.on_select && typeof starwarsjs.on_select === "function"){
 
                         starwarsjs.on_select(star_id);


### PR DESCRIPTION
In many senarios you may need access to the stars parent,
for example in my system I can have infinite rows of stars and rather than duplicate code by as many reviews that I need.
In the "on_select" function I can now just do "this.active_element.id". This means I can query the server and know which item I am rating on
rather than having to duplicate that code many many times.
